### PR TITLE
WIP: Support Rails 5.0

### DIFF
--- a/db/migrate/20150929144540_add_view_replace_function.rb
+++ b/db/migrate/20150929144540_add_view_replace_function.rb
@@ -1,4 +1,4 @@
-class AddViewReplaceFunction < ActiveRecord::Migration
+class AddViewReplaceFunction < ActiveRecord::Migration[5.0]
   def up
     function_sql = <<-SQL
       CREATE OR REPLACE FUNCTION replace_view(view_name TEXT, new_sql TEXT) RETURNS VOID AS $$

--- a/db/migrate/20150929205301_add_view_dependencies.rb
+++ b/db/migrate/20150929205301_add_view_dependencies.rb
@@ -1,4 +1,4 @@
-class AddViewDependencies < ActiveRecord::Migration
+class AddViewDependencies < ActiveRecord::Migration[5.0]
   def up
     view_dependency_function_sql = <<-SQL
       CREATE OR REPLACE FUNCTION view_dependencies(materialized_view NAME)

--- a/db/migrate/20151005150022_update_dependency_views.rb
+++ b/db/migrate/20151005150022_update_dependency_views.rb
@@ -1,4 +1,4 @@
-class UpdateDependencyViews < ActiveRecord::Migration
+class UpdateDependencyViews < ActiveRecord::Migration[5.0]
   def up
     dependency_sql = <<-SQL
       DROP MATERIALIZED VIEW materialized_view_dependencies;

--- a/db/migrate/20160512173021_update_view_replace_function.rb
+++ b/db/migrate/20160512173021_update_view_replace_function.rb
@@ -1,4 +1,4 @@
-class UpdateViewReplaceFunction < ActiveRecord::Migration
+class UpdateViewReplaceFunction < ActiveRecord::Migration[5.0]
   def up
     function_sql = <<-SQL
       CREATE OR REPLACE FUNCTION replace_view(view_name TEXT, new_sql TEXT) RETURNS VOID AS $$

--- a/db/migrate/20160513141153_add_index_recreation.rb
+++ b/db/migrate/20160513141153_add_index_recreation.rb
@@ -1,4 +1,4 @@
-class AddIndexRecreation < ActiveRecord::Migration
+class AddIndexRecreation < ActiveRecord::Migration[5.0]
   def up
     function_sql = <<-SQL
       CREATE OR REPLACE FUNCTION replace_view(view_name TEXT, new_sql TEXT) RETURNS VOID AS $$

--- a/lib/viewy/acts_as_materialized_view.rb
+++ b/lib/viewy/acts_as_materialized_view.rb
@@ -41,7 +41,7 @@ module Viewy
         result = connection.execute <<-SQL
           SELECT ispopulated FROM pg_matviews WHERE matviewname = '#{self.table_name}';
         SQL
-        ActiveRecord::Type::Boolean.new.type_cast_from_user(result.values[0][0])
+        ActiveRecord::Type::Boolean.new.cast(result.values[0][0])
       end
     end
   end

--- a/lib/viewy/dependency_management/view_refresher.rb
+++ b/lib/viewy/dependency_management/view_refresher.rb
@@ -61,7 +61,7 @@ module Viewy
       #   refresh has failed.  Since Postgres raises an error when an unpopulated view is refreshed concurrently, this
       #   allows the system to populated such views if needed
       private def attempt_non_concurrent_refresh?(ex, concurrently)
-        original_exception = ex.original_exception
+        original_exception = ex.cause
         should_retry_non_concurrently = original_exception.instance_of?(PG::FeatureNotSupported) ||
           original_exception.instance_of?(PG::ObjectNotInPrerequisiteState)
 

--- a/lib/viewy/version.rb
+++ b/lib/viewy/version.rb
@@ -1,3 +1,3 @@
 module Viewy
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
 #Viewy
 
-##NOTE this is only for use with postgres 9.4 or higher.  
+## Versions
+
+For Rails 4, use 0.4.0 or below. For Rails 5, use 0.5.0 or above.
+
+##NOTE this is only for use with postgres 9.4 or higher.
 
 In a nutshell, it provides two separate functionalities:
 
@@ -10,7 +14,7 @@ view_manager = Viewy::DependencyManager.new
 view_manager.replace_view(
   'd',
    <<-SQL
-     SELECT * FROM ... 
+     SELECT * FROM ...
    SQL
 )
 ```

--- a/spec/dependency_management/view_refresher_spec.rb
+++ b/spec/dependency_management/view_refresher_spec.rb
@@ -89,7 +89,9 @@ describe Viewy::DependencyManagement::ViewRefresher do
       end
       context 'failure is because concurrent refresh failed' do
         let(:statement_invalid) do
-          ActiveRecord::StatementInvalid.new('CONCURRENTLY failed on view')
+          exception = ActiveRecord::StatementInvalid.new('CONCURRENTLY failed on view')
+          allow(exception).to receive(:cause).and_return(PG::ObjectNotInPrerequisiteState.new)
+          exception
         end
 
         it 'refreshes the failed view non-concurrently' do

--- a/spec/dependency_management/view_refresher_spec.rb
+++ b/spec/dependency_management/view_refresher_spec.rb
@@ -89,7 +89,7 @@ describe Viewy::DependencyManagement::ViewRefresher do
       end
       context 'failure is because concurrent refresh failed' do
         let(:statement_invalid) do
-          ActiveRecord::StatementInvalid.new('CONCURRENTLY failed on view', PG::FeatureNotSupported.new)
+          ActiveRecord::StatementInvalid.new('CONCURRENTLY failed on view')
         end
 
         it 'refreshes the failed view non-concurrently' do
@@ -102,7 +102,7 @@ describe Viewy::DependencyManagement::ViewRefresher do
       end
       context 'failure is for another reason' do
         let(:statement_invalid) do
-          ActiveRecord::StatementInvalid.new('Everything failed', RuntimeError.new)
+          ActiveRecord::StatementInvalid.new('Everything failed')
         end
 
         it 'raises the error back to the caller' do

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -25,8 +25,6 @@ module Dummy
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -9,12 +9,27 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Show full error reports.
+  config.consider_all_requests_local = true
+
+  # Enable/disable caching. By default caching is disabled.
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=172800'
+    }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -27,15 +42,13 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
-  config.assets.digest = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Use an evented file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc. This feature depends on the listen gem.
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -14,15 +14,9 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -31,15 +25,19 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
-  config.assets.digest = true
-
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -49,16 +47,15 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "dummy_#{Rails.env}"
+  config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -73,6 +70,16 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -12,9 +12,11 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=3600'
+  }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
@@ -25,14 +27,12 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
+  config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-
-  # Randomize the order test cases are executed.
-  config.active_support.test_order = :random
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/dummy/db/migrate/20171027181119_generate_dummy_view_hierarchy.rb
+++ b/spec/dummy/db/migrate/20171027181119_generate_dummy_view_hierarchy.rb
@@ -1,4 +1,4 @@
-class GenerateDummyViewHierarchy < ActiveRecord::Migration
+class GenerateDummyViewHierarchy < ActiveRecord::Migration[5.0]
   # Creates a hierarchy of views with dependencies with the following graph, where V = view and M = materialized view
   #
   #           main_view

--- a/viewy.gemspec
+++ b/viewy.gemspec
@@ -16,9 +16,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4'
+  s.add_dependency 'rails', '~> 5.0.0'
 
-  s.add_development_dependency 'pg'
+  s.add_development_dependency 'listen'
+  s.add_development_dependency 'pg', '< 1.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers', '~> 3.0'
 end


### PR DESCRIPTION
This is currently a WIP because I cannot get spec/dependency_management/view_refresher_spec.rb:96 to pass. It appears that the `and_raise` is causing the error to be raised within RSpec rather than in the application code, so the `rescue` within the application code is not catching the error. Instead, the spec blows up.

I'm not sure if this is a bug within RSpec or intended behavior. I've tried a couple different approaches and can't get the correct behavior.