### PR TITLE
Add migration to add schema names to view dependencies

### DIFF
--- a/db/migrate/20180525142127_add_schema_name_to_view_dependencies.rb
+++ b/db/migrate/20180525142127_add_schema_name_to_view_dependencies.rb
@@ -1,0 +1,253 @@
+class AddSchemaNameToViewDependencies < ActiveRecord::Migration[5.2]
+  def up
+    drop_statement = <<-SQL
+      DROP MATERIALIZED VIEW all_view_dependencies;
+      DROP MATERIALIZED VIEW materialized_view_dependencies;
+      DROP FUNCTION all_view_dependencies(name);
+      DROP FUNCTION view_dependencies(name);
+    SQL
+    execute(drop_statement)
+
+    view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION view_dependencies(materialized_view NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+          WHERE NOT dg.cycle
+        ), dependencies AS(
+            SELECT
+              pg_class.relname AS view_name,
+              schemas.nspname AS schema_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            LEFT JOIN pg_class ON pg_class.OID = dependency_graph.oid
+            LEFT JOIN pg_catalog.pg_namespace schemas ON schemas.oid = pg_class.relnamespace
+            GROUP BY dependency_graph.OID, pg_class.relname, schemas.nspname
+            ORDER BY min_depth
+        )
+        SELECT ARRAY(SELECT dependencies.schema_name || '.' || dependencies.view_name FROM
+          dependencies
+          JOIN pg_matviews
+            ON pg_matviews.matviewname = dependencies.view_name
+              AND pg_matviews.schemaname = dependencies.schema_name
+        WHERE dependencies.view_name != materialized_view)
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(view_dependencies_function_sql)
+
+    all_view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION all_view_dependencies(materialized_view NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+            JOIN pg_class ON dependents.refobjid = pg_class.OID
+            JOIN pg_authid ON pg_class.relowner = pg_authid.OID AND pg_authid.rolname != 'postgres'
+          WHERE NOT dg.cycle AND pg_class.relkind IN ('m', 'v')
+        ), dependencies AS(
+            SELECT
+              pg_class.relname AS view_name,
+              schemas.nspname AS schema_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            LEFT JOIN pg_class ON pg_class.OID = dependency_graph.oid
+            LEFT JOIN pg_catalog.pg_namespace schemas ON schemas.oid = pg_class.relnamespace
+            GROUP BY dependency_graph.OID, pg_class.relname, schemas.nspname
+            ORDER BY min_depth
+        )
+        SELECT ARRAY(
+          SELECT dependencies.schema_name || '.' || dependencies.view_name
+          FROM dependencies
+            LEFT JOIN pg_matviews
+                   ON pg_matviews.matviewname = dependencies.view_name
+                     AND pg_matviews.schemaname = dependencies.schema_name
+            LEFT JOIN pg_views
+                   ON pg_views.viewname = dependencies.view_name
+                     AND pg_views.schemaname = dependencies.schema_name
+          WHERE dependencies.view_name != materialized_view
+        )
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(all_view_dependencies_function_sql)
+
+    all_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW all_view_dependencies AS
+        WITH normal_view_dependencies AS (
+          SELECT
+            schemaname || '.' || viewname AS view_name,
+            all_view_dependencies(viewname) AS view_dependencies
+          FROM pg_views
+          WHERE viewowner != 'postgres'
+        ),
+         matview_dependencies AS (
+          SELECT
+            schemaname || '.' || matviewname AS view_name,
+            all_view_dependencies(matviewname)  AS view_dependencies
+          FROM pg_matviews
+          WHERE matviewowner != 'postgres'
+        )
+          SELECT matview_dependencies.*, TRUE as materialized_view FROM matview_dependencies
+        UNION
+          SELECT normal_view_dependencies.*, FALSE AS materialized_view FROM normal_view_dependencies;
+    SQL
+    execute(all_view_dependency_sql)
+
+    materialized_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW materialized_view_dependencies AS
+        SELECT
+          schemaname || '.' || matviewname AS view_name,
+          view_dependencies(matviewname),
+          TRUE AS materialized_view
+        FROM pg_matviews
+        WHERE matviewname != 'materialized_view_dependencies' AND matviewname != 'all_view_dependencies'
+      ;
+    SQL
+    execute(materialized_view_dependency_sql)
+  end
+
+  def down
+    drop_statement = <<-SQL
+      DROP MATERIALIZED VIEW all_view_dependencies;
+      DROP MATERIALIZED VIEW materialized_view_dependencies;
+      DROP FUNCTION all_view_dependencies(name);
+      DROP FUNCTION view_dependencies(name);
+    SQL
+    execute(drop_statement)
+
+    view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION view_dependencies(materialized_view NAME)
+        RETURNS NAME[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+          WHERE NOT dg.cycle
+        ), dependencies AS(
+            SELECT
+              (SELECT relname FROM pg_class WHERE pg_class.OID = dependency_graph.oid) AS view_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            GROUP BY dependency_graph.OID ORDER BY min_depth
+        )
+        SELECT ARRAY(SELECT dependencies.view_name FROM
+          dependencies
+          JOIN pg_matviews ON pg_matviews.matviewname = dependencies.view_name
+        WHERE dependencies.view_name != materialized_view)
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(view_dependencies_function_sql)
+
+    all_view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION all_view_dependencies(materialized_view NAME)
+        RETURNS NAME[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+            JOIN pg_class ON dependents.refobjid = pg_class.OID
+            JOIN pg_authid ON pg_class.relowner = pg_authid.OID AND pg_authid.rolname != 'postgres'
+          WHERE NOT dg.cycle AND pg_class.relkind IN ('m', 'v')
+        ), dependencies AS(
+            SELECT
+              (SELECT relname FROM pg_class WHERE pg_class.OID = dependency_graph.oid) AS view_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            GROUP BY dependency_graph.OID ORDER BY min_depth
+        )
+        SELECT ARRAY(
+          SELECT dependencies.view_name
+          FROM dependencies
+            LEFT JOIN pg_matviews ON pg_matviews.matviewname = dependencies.view_name
+            LEFT JOIN pg_views ON pg_views.viewname = dependencies.view_name
+          WHERE dependencies.view_name != materialized_view
+        )
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(all_view_dependencies_function_sql)
+
+    all_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW all_view_dependencies AS
+        WITH normal_view_dependencies AS (
+          SELECT
+            viewname AS view_name,
+            all_view_dependencies(viewname) AS view_dependencies
+          FROM pg_views
+          WHERE viewowner != 'postgres'
+        ),
+         matview_dependencies AS (
+          SELECT
+            matviewname AS view_name,
+            all_view_dependencies(matviewname)  AS view_dependencies
+          FROM pg_matviews
+          WHERE matviewowner != 'postgres'
+        )
+          SELECT matview_dependencies.*, TRUE as materialized_view FROM matview_dependencies
+        UNION
+          SELECT normal_view_dependencies.*, FALSE AS materialized_view FROM normal_view_dependencies;
+    SQL
+    execute(all_view_dependency_sql)
+
+    materialized_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW materialized_view_dependencies AS
+        SELECT
+          matviewname AS view_name,
+          view_dependencies(matviewname),
+          TRUE AS materialized_view
+        FROM pg_matviews
+        WHERE matviewname != 'materialized_view_dependencies' AND matviewname != 'all_view_dependencies'
+      ;
+    SQL
+    execute(materialized_view_dependency_sql)
+  end
+end

--- a/db/migrate/20180528165706_update_schema_name_in_view_dependencies.rb
+++ b/db/migrate/20180528165706_update_schema_name_in_view_dependencies.rb
@@ -1,0 +1,300 @@
+class UpdateSchemaNameInViewDependencies < ActiveRecord::Migration[5.0]
+
+  def up
+    drop_statement = <<-SQL
+      DROP MATERIALIZED VIEW all_view_dependencies;
+      DROP MATERIALIZED VIEW materialized_view_dependencies;
+      DROP FUNCTION all_view_dependencies(name);
+      DROP FUNCTION view_dependencies(name);
+    SQL
+    execute(drop_statement)
+
+    view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION view_dependencies(materialized_view NAME, view_schema NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+          WHERE NOT dg.cycle
+        ), dependencies AS(
+          SELECT
+            (
+              SELECT
+               nspname || '.' || relname
+              FROM pg_class
+                JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS view_name,
+            (
+              SELECT
+               nspname
+              FROM pg_class
+                JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS schema_name,
+            (
+              SELECT
+               relname
+              FROM pg_class
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS name,
+            dependency_graph.OID,
+            MIN(depth) AS min_depth
+          FROM dependency_graph
+          GROUP BY dependency_graph.OID
+          ORDER BY min_depth
+        )
+        SELECT ARRAY(
+          SELECT dependencies.view_name
+          FROM dependencies
+            JOIN pg_matviews ON pg_matviews.matviewname = dependencies.name AND pg_matviews.schemaname = dependencies.schema_name
+          WHERE dependencies.view_name != (view_schema || '.' || materialized_view) 
+        )
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(view_dependencies_function_sql)
+
+    all_view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION all_view_dependencies(materialized_view NAME, view_schema NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT pg_class.oid, 1, ARRAY[pg_class.oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+            JOIN pg_class ON dependents.refobjid = pg_class.OID
+            JOIN pg_authid ON pg_class.relowner = pg_authid.OID AND pg_authid.rolname != 'postgres'
+          WHERE NOT dg.cycle AND pg_class.relkind IN ('m', 'v')
+        ), dependencies AS(
+            SELECT
+            (
+              SELECT
+               nspname || '.' || relname
+              FROM pg_class
+                JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS view_name,
+            (
+              SELECT
+               nspname
+              FROM pg_class
+                JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS schema_name,
+            (
+              SELECT
+               relname
+              FROM pg_class
+              WHERE pg_class.OID = dependency_graph.oid
+            ) AS name,
+            dependency_graph.OID,
+            MIN(depth) AS min_depth
+          FROM dependency_graph
+          GROUP BY dependency_graph.OID
+          ORDER BY min_depth
+        )
+        SELECT ARRAY(
+          SELECT dependencies.view_name 
+          FROM dependencies
+            LEFT JOIN pg_matviews  
+              ON pg_matviews.matviewname = dependencies.name 
+              AND pg_matviews.schemaname = dependencies.schema_name
+            LEFT JOIN pg_views 
+              ON pg_views.viewname = dependencies.name 
+              AND pg_matviews.schemaname = dependencies.schema_name
+          WHERE dependencies.view_name != (view_schema || '.' || materialized_view)
+        )
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(all_view_dependencies_function_sql)
+
+    all_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW all_view_dependencies AS
+        WITH normal_view_dependencies AS (
+          SELECT 
+            schemaname || '.' || viewname AS view_name, 
+            all_view_dependencies(viewname, schemaname) AS view_dependencies 
+          FROM pg_views 
+          WHERE viewowner != 'postgres'
+        ),
+         matview_dependencies AS (
+          SELECT 
+            schemaname || '.' || matviewname AS view_name, 
+            all_view_dependencies(matviewname, schemaname)  AS view_dependencies
+          FROM pg_matviews 
+          WHERE matviewowner != 'postgres'
+        )
+          SELECT matview_dependencies.*, TRUE as materialized_view FROM matview_dependencies
+        UNION
+          SELECT normal_view_dependencies.*, FALSE AS materialized_view FROM normal_view_dependencies;
+    SQL
+    execute(all_view_dependency_sql)
+
+    materialized_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW materialized_view_dependencies AS
+        SELECT
+          schemaname || '.' || matviewname AS view_name,
+          view_dependencies(matviewname, schemaname),
+          TRUE AS materialized_view
+        FROM pg_matviews
+        WHERE matviewname != 'materialized_view_dependencies' AND matviewname != 'all_view_dependencies'
+      ;
+    SQL
+    execute(materialized_view_dependency_sql)
+  end
+
+  def down
+    drop_statement = <<-SQL
+      DROP MATERIALIZED VIEW all_view_dependencies;
+      DROP MATERIALIZED VIEW materialized_view_dependencies;
+      DROP FUNCTION all_view_dependencies(name, name);
+      DROP FUNCTION view_dependencies(name, name);
+    SQL
+    execute(drop_statement)
+
+    view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION view_dependencies(materialized_view NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+          WHERE NOT dg.cycle
+        ), dependencies AS(
+            SELECT
+              pg_class.relname AS view_name,
+              schemas.nspname AS schema_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            LEFT JOIN pg_class ON pg_class.OID = dependency_graph.oid
+            LEFT JOIN pg_catalog.pg_namespace schemas ON schemas.oid = pg_class.relnamespace
+            GROUP BY dependency_graph.OID, pg_class.relname, schemas.nspname
+            ORDER BY min_depth
+        )
+        SELECT ARRAY(SELECT dependencies.schema_name || '.' || dependencies.view_name FROM
+          dependencies
+          JOIN pg_matviews
+            ON pg_matviews.matviewname = dependencies.view_name
+              AND pg_matviews.schemaname = dependencies.schema_name
+        WHERE dependencies.view_name != materialized_view)
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(view_dependencies_function_sql)
+
+    all_view_dependencies_function_sql = <<-SQL
+      CREATE OR REPLACE FUNCTION all_view_dependencies(materialized_view NAME)
+        RETURNS TEXT[]
+      AS $$
+        WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
+          SELECT oid, 1, ARRAY[oid], FALSE
+          FROM pg_class
+          WHERE relname = materialized_view
+          UNION
+          SELECT
+            dependents.refobjid,
+            dg.depth + 1,
+            dg.path || dependents.refobjid,
+            dependents.refobjid = ANY(dg.path)
+          FROM dependency_graph dg
+            JOIN pg_rewrite rewrites ON rewrites.ev_class = dg.oid
+            JOIN pg_depend dependents ON dependents.objid = rewrites.oid
+            JOIN pg_class ON dependents.refobjid = pg_class.OID
+            JOIN pg_authid ON pg_class.relowner = pg_authid.OID AND pg_authid.rolname != 'postgres'
+          WHERE NOT dg.cycle AND pg_class.relkind IN ('m', 'v')
+        ), dependencies AS(
+            SELECT
+              pg_class.relname AS view_name,
+              schemas.nspname AS schema_name,
+              dependency_graph.OID,
+              MIN(depth) AS min_depth
+            FROM dependency_graph
+            LEFT JOIN pg_class ON pg_class.OID = dependency_graph.oid
+            LEFT JOIN pg_catalog.pg_namespace schemas ON schemas.oid = pg_class.relnamespace
+            GROUP BY dependency_graph.OID, pg_class.relname, schemas.nspname
+            ORDER BY min_depth
+        )
+        SELECT ARRAY(
+          SELECT dependencies.schema_name || '.' || dependencies.view_name
+          FROM dependencies
+            LEFT JOIN pg_matviews
+                   ON pg_matviews.matviewname = dependencies.view_name
+                     AND pg_matviews.schemaname = dependencies.schema_name
+            LEFT JOIN pg_views
+                   ON pg_views.viewname = dependencies.view_name
+                     AND pg_views.schemaname = dependencies.schema_name
+          WHERE dependencies.view_name != materialized_view
+        )
+        ;
+      $$ LANGUAGE SQL;
+    SQL
+    execute(all_view_dependencies_function_sql)
+
+    all_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW all_view_dependencies AS
+        WITH normal_view_dependencies AS (
+          SELECT
+            schemaname || '.' || viewname AS view_name,
+            all_view_dependencies(viewname) AS view_dependencies
+          FROM pg_views
+          WHERE viewowner != 'postgres'
+        ),
+         matview_dependencies AS (
+          SELECT
+            schemaname || '.' || matviewname AS view_name,
+            all_view_dependencies(matviewname)  AS view_dependencies
+          FROM pg_matviews
+          WHERE matviewowner != 'postgres'
+        )
+          SELECT matview_dependencies.*, TRUE as materialized_view FROM matview_dependencies
+        UNION
+          SELECT normal_view_dependencies.*, FALSE AS materialized_view FROM normal_view_dependencies;
+    SQL
+    execute(all_view_dependency_sql)
+
+    materialized_view_dependency_sql = <<-SQL
+      CREATE MATERIALIZED VIEW materialized_view_dependencies AS
+        SELECT
+          schemaname || '.' || matviewname AS view_name,
+          view_dependencies(matviewname),
+          TRUE AS materialized_view
+        FROM pg_matviews
+        WHERE matviewname != 'materialized_view_dependencies' AND matviewname != 'all_view_dependencies'
+      ;
+    SQL
+    execute(materialized_view_dependency_sql)
+  end
+end

--- a/db/migrate/20180528165706_update_schema_name_in_view_dependencies.rb
+++ b/db/migrate/20180528165706_update_schema_name_in_view_dependencies.rb
@@ -14,8 +14,9 @@ class UpdateSchemaNameInViewDependencies < ActiveRecord::Migration[5.0]
         RETURNS TEXT[]
       AS $$
         WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
-          SELECT oid, 1, ARRAY[oid], FALSE
+          SELECT pg_class.oid, 1, ARRAY[pg_class.oid], FALSE
           FROM pg_class
+            JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID AND pg_namespace.nspname = view_schema
           WHERE relname = materialized_view
           UNION
           SELECT
@@ -73,6 +74,7 @@ class UpdateSchemaNameInViewDependencies < ActiveRecord::Migration[5.0]
         WITH RECURSIVE dependency_graph(oid, depth, path, cycle) AS (
           SELECT pg_class.oid, 1, ARRAY[pg_class.oid], FALSE
           FROM pg_class
+            JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.OID AND pg_namespace.nspname = view_schema
           WHERE relname = materialized_view
           UNION
           SELECT

--- a/lib/viewy/acts_as_materialized_view.rb
+++ b/lib/viewy/acts_as_materialized_view.rb
@@ -13,8 +13,7 @@ module Viewy
       # @return [PG::Result] the result of the refresh statement on the materialized view
       def refresh!(concurrently: false)
         refresher = Viewy::DependencyManagement::ViewRefresher.new(Viewy.connection)
-        view_name = "#{schema_name}.#{table_name}"
-        refresher.refresh_materialized_view(view_name, with_dependencies: true, concurrently: concurrently)
+        refresher.refresh_materialized_view(full_table_name, with_dependencies: true, concurrently: concurrently)
       end
 
       # Refreshes this view without refreshing any dependencies
@@ -24,14 +23,14 @@ module Viewy
       # @return [PG::Result] the result of the refresh statement on the materialized view
       def refresh_without_dependencies!(concurrently: false)
         refresher = Viewy::DependencyManagement::ViewRefresher.new(Viewy.connection)
-        refresher.refresh_materialized_view(table_name, with_dependencies: false, concurrently: concurrently)
+        refresher.refresh_materialized_view(full_table_name, with_dependencies: false, concurrently: concurrently)
       end
 
       # Provides an array of sorted view dependencies
       #
       # @return [Array<String>]
       def sorted_view_dependencies
-        view_dep = Viewy::Models::MaterializedViewDependency.find(table_name)
+        view_dep = Viewy::Models::MaterializedViewDependency.find(full_table_name)
         Viewy::DependencyManagement::ViewSorter.new.sorted_materialized_view_subset(view_names: view_dep.view_dependencies)
       end
 
@@ -39,14 +38,27 @@ module Viewy
       #
       # @return [Boolean] true if the view has been populated, false if not
       def populated?
-        result = connection.execute <<-SQL
-          SELECT ispopulated FROM pg_matviews WHERE matviewname = '#{self.table_name}';
+        query = <<-SQL
+          SELECT ispopulated 
+          FROM pg_matviews 
+          WHERE matviewname = '#{table_name}' 
+            AND schemaname = '#{schema_name.chomp('.')}';
         SQL
+        result = connection.execute query
         ActiveRecord::Type::Boolean.new.cast(result.values[0][0])
       end
 
+      private def full_table_name
+        "#{schema_name}#{table_name}"
+      end
+
       private def schema_name
-        connection.current_schema
+        chunks = table_name.to_s.partition('.')
+        if chunks[2].present?
+          ''
+        else
+          "#{connection.current_schema}."
+        end
       end
     end
   end

--- a/lib/viewy/acts_as_materialized_view.rb
+++ b/lib/viewy/acts_as_materialized_view.rb
@@ -13,7 +13,8 @@ module Viewy
       # @return [PG::Result] the result of the refresh statement on the materialized view
       def refresh!(concurrently: false)
         refresher = Viewy::DependencyManagement::ViewRefresher.new(Viewy.connection)
-        refresher.refresh_materialized_view(table_name, with_dependencies: true, concurrently: concurrently)
+        view_name = "#{schema_name}.#{table_name}"
+        refresher.refresh_materialized_view(view_name, with_dependencies: true, concurrently: concurrently)
       end
 
       # Refreshes this view without refreshing any dependencies
@@ -42,6 +43,10 @@ module Viewy
           SELECT ispopulated FROM pg_matviews WHERE matviewname = '#{self.table_name}';
         SQL
         ActiveRecord::Type::Boolean.new.cast(result.values[0][0])
+      end
+
+      private def schema_name
+        connection.current_schema
       end
     end
   end

--- a/lib/viewy/acts_as_view.rb
+++ b/lib/viewy/acts_as_view.rb
@@ -12,9 +12,11 @@ module Viewy
       #
       # @return [nil]
       def refresh!
-        view_dep = Viewy::Models::MaterializedViewDependency.find(table_name)
-        view_dep.view_dependencies.each do |view_dependency|
-          ActiveRecord::Base.connection.execute("REFRESH MATERIALIZED VIEW #{view_dependency}")
+        view_dep = Viewy::Models::ViewDependency.find(table_name)
+        deps = Viewy::DependencyManagement::ViewSorter.new.sorted_view_subset(view_names: view_dep.view_dependencies)
+        deps.each do |view_dependency|
+          materialized_view_dependency = Viewy::Models::MaterializedViewDependency.find_by(view_name: view_dependency)
+          ActiveRecord::Base.connection.execute("REFRESH MATERIALIZED VIEW #{view_dependency}") if materialized_view_dependency
         end
       end
     end

--- a/lib/viewy/dependency_management/view_refresher.rb
+++ b/lib/viewy/dependency_management/view_refresher.rb
@@ -42,6 +42,7 @@ module Viewy
       end
 
       private def refresh_single_view(view_name, concurrently:)
+        view_name = view_name.split('.').last
         begin
           connection.execute(refresh_sql(view_name, concurrently))
         rescue ActiveRecord::StatementInvalid => ex

--- a/lib/viewy/dependency_manager.rb
+++ b/lib/viewy/dependency_manager.rb
@@ -23,12 +23,13 @@ module Viewy
     # NOTE: this is provided as a convenience for managing dependencies, and the user should not expect that the
     # re-created views will function if they rely on parts of the replaced view that are removed.
     #
-    # @param view_name [String] the name of the view being replaced
+    # @param view_name [String] the name of the view being replaced (optionally schema-qualified)
     # @param new_definition_sql [String] the SQL definition of the new view
     #
     # @raise [ActiveRecord::StatementInvalidError] raised if a dependent view is somehow not refreshed correctly
     # @return [PG::Result] the result of the refresh statement on the materialized view
     def replace_view(view_name, new_definition_sql, &block)
+      view_name = view_name.split('.').last
       Viewy.connection.execute("SELECT replace_view('#{view_name}', $$#{new_definition_sql}$$)")
       block.call if block_given?
     end

--- a/spec/acts_as_materialized_view_spec.rb
+++ b/spec/acts_as_materialized_view_spec.rb
@@ -24,3 +24,26 @@ describe MainView do
     end
   end
 end
+
+class FooMatView < ActiveRecord::Base
+  include Viewy::ActsAsMaterializedView
+
+  self.table_name = 'foo.mat_view'
+end
+
+describe FooMatView do
+  describe '.sorted_view_dependencies' do
+    it 'returns the view dependencies' do
+      expect(described_class.sorted_view_dependencies).to eql ['public.mat_view_1']
+    end
+  end
+  describe '.refresh!' do
+    it 'does not raise an error' do
+      expect {
+        described_class.refresh!
+      }.not_to raise_error
+    end
+  end
+end
+
+

--- a/spec/acts_as_view_spec.rb
+++ b/spec/acts_as_view_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe FooOtherView do
+  describe 'refresh!' do
+    before do
+      Viewy.refresh_all_dependency_information
+    end
+
+    it 'does not raise an error' do
+      expect {
+        described_class.refresh!
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/dummy/app/models/foo_other_view.rb
+++ b/spec/dummy/app/models/foo_other_view.rb
@@ -1,0 +1,5 @@
+class FooOtherView < ActiveRecord::Base
+  include Viewy::ActsAsView
+
+  self.table_name = 'foo.other_view'
+end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -21,7 +21,7 @@ development:
   password: <%= ENV['POSTGRES_PASS'] %>
   host: localhost
   port: <%= ENV['APP_PORT'] %>
-  schema_search_path: public
+  schema_search_path: public,foo
 
 test:
   adapter: postgresql
@@ -32,5 +32,5 @@ test:
   password: <%= ENV['POSTGRES_PASS'] %>
   host: localhost
   port: <%= ENV['APP_PORT'] %>
-  schema_search_path: public
+  schema_search_path: public,foo
 

--- a/spec/dummy/db/migrate/20180518193352_add_non_materialized_views.rb
+++ b/spec/dummy/db/migrate/20180518193352_add_non_materialized_views.rb
@@ -1,11 +1,15 @@
 class AddNonMaterializedViews < ActiveRecord::Migration[5.0]
   # Creates a hierarchy of views with dependencies with the following graph, where V = view and M = materialized view
-  #
-  #    V1        V4
-  #  /   \
-  # V2    V3
-  # |
-  # M2 (see generate_dummy_view_hierarchy.rb)
+  #                   main_view               TV4
+  #                 /     |     \
+  #               M7     V4      M8
+  #             /   \       \   /  \
+  #   tv1      M4   V3       M5     M6
+  #  /   \    |      \     /       |
+  # tv3  tv2  V1      \   /        V2
+  #         \ |         M3
+  #          M2        |
+  #                     M1
   def up
     execute <<-SQL
       CREATE VIEW test_view_2 AS

--- a/spec/dummy/db/migrate/20180528164845_add_views_in_other_schema.rb
+++ b/spec/dummy/db/migrate/20180528164845_add_views_in_other_schema.rb
@@ -1,0 +1,25 @@
+class AddViewsInOtherSchema < ActiveRecord::Migration[5.0]
+  def up
+    execute <<-SQL
+      CREATE SCHEMA foo;
+      CREATE VIEW foo.test_view_3 AS
+        SELECT 
+          public.test_view_3.col_1 AS col_1,
+          'baz'::TEXT AS col_2
+        FROM test_view_3;
+      CREATE VIEW foo.other_view AS 
+        SELECT 
+          main_view.label AS col_1,
+          foo.test_view_3.col_2 AS col_2
+        FROM foo.test_view_3, public.main_view;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP VIEW foo.other_view;
+      DROP VIEW foo.test_view_3;
+      DROP SCHEMA foo;
+    SQL
+  end
+end

--- a/spec/dummy/db/migrate/20180528211227_add_materialized_view_in_foo_namespace.rb
+++ b/spec/dummy/db/migrate/20180528211227_add_materialized_view_in_foo_namespace.rb
@@ -1,0 +1,16 @@
+class AddMaterializedViewInFooNamespace < ActiveRecord::Migration[5.0]
+  def up
+    execute <<~SQL
+      CREATE MATERIALIZED VIEW foo.mat_view AS
+      SELECT 
+        public.mat_view_1.label AS label
+       FROM mat_view_1;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP MATERIALIZED VIEW foo.mat_view
+    SQL
+  end
+end

--- a/spec/features/sorted_view_dependencies_spec.rb
+++ b/spec/features/sorted_view_dependencies_spec.rb
@@ -3,32 +3,52 @@ require 'rails_helper'
 describe Viewy do
   describe '#view_names_in_dependency_order' do
     it 'returns the names of all views in the system in a topologically safe order' do
-      expected_view_names = %w(
-        mat_view_2
-        view_1
-        mat_view_1
-        mat_view_3
-        view_3
-        view_2
-        mat_view_6
-        mat_view_5
-        mat_view_8
-        mat_view_4
-        mat_view_7
-        main_view
-        materialized_view_dependencies
-        test_view_4
-        test_view_2
-        test_view_3
-        test_view_1
-        view_4
-        all_view_dependencies
-      )
-      expect(Viewy.view_names_in_dependency_order).to eql expected_view_names
+      dependency_orders = {
+        'public.mat_view_3' => %w[public.mat_view_1],
+        'public.view_1'     => %w[public.mat_view_2],
+        'public.mat_view_4' => %w[public.view_1],
+        'public.mat_view_5' => %w[public.mat_view_3],
+        'public.mat_view_6' => %w[public.view_2],
+        'public.view_3'     => %w[public.mat_view_3],
+        'public.mat_view_7' => %w[public.view_3 public.mat_view_4],
+        'public.mat_view_8' => %w[public.mat_view_5 public.mat_view_6],
+        'public.main_view'  => %w[public.mat_view_7 public.mat_view_8]
+      }
+
+      expected_view_names = %w[
+        public.mat_view_2
+        public.view_1
+        public.mat_view_1
+        public.mat_view_3
+        public.view_3
+        public.view_2
+        public.mat_view_6
+        public.mat_view_5
+        public.mat_view_8
+        public.mat_view_4
+        public.mat_view_7
+        public.main_view
+        public.materialized_view_dependencies
+        public.test_view_4
+        public.test_view_2
+        public.test_view_3
+        public.test_view_1
+        public.view_4
+        public.all_view_dependencies
+      ]
+
+      result = Viewy.view_names_in_dependency_order
+      expect(result).to match_array(expected_view_names)
+      dependency_orders.each do |view, dependencies|
+        dependencies.each do |dependency|
+          expect(result.index(dependency)).to be < result.index(view)
+        end
+      end
+
       result = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT 
-          matviewname, 
-          'CREATE MATERIALIZED VIEW AS ' || definition 
+        SELECT
+          matviewname,
+          'CREATE MATERIALIZED VIEW AS ' || definition
         FROM pg_matviews WHERE matviewowner != 'postgres';
       SQL
       views = {}
@@ -36,17 +56,17 @@ describe Viewy do
         views[tuple[0]] = tuple[1]
       end
       result = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT 
-          viewname, 
-          'CREATE VIEW AS ' || definition 
-        FROM pg_views 
+        SELECT
+          viewname,
+          'CREATE VIEW AS ' || definition
+        FROM pg_views
         WHERE viewowner != 'postgres';
       SQL
       result.values.each do |tuple|
         views[tuple[0]] = tuple[1]
       end
-      views.delete 'all_view_dependencies'
-      views.delete  'materialized_view_dependencies'
+      views.delete 'public.all_view_dependencies'
+      views.delete 'public.materialized_view_dependencies'
 
       expect {
         Viewy.view_names_in_dependency_order.reverse.each do |name|

--- a/spec/features/sorted_view_dependencies_spec.rb
+++ b/spec/features/sorted_view_dependencies_spec.rb
@@ -35,6 +35,9 @@ describe Viewy do
         public.test_view_1
         public.view_4
         public.all_view_dependencies
+        foo.test_view_3
+        foo.other_view
+        foo.mat_view
       ]
 
       result = Viewy.view_names_in_dependency_order

--- a/spec/models/materialized_view_dependency_spec.rb
+++ b/spec/models/materialized_view_dependency_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Viewy::Models::MaterializedViewDependency do
   describe 'columns' do
-    it { is_expected.to have_db_column(:view_name).of_type(:string) }
+    it { is_expected.to have_db_column(:view_name).of_type(:text) }
     it { is_expected.to have_db_column(:materialized_view).of_type(:boolean) }
     it { is_expected.to have_db_column(:view_dependencies) }
   end

--- a/spec/models/view_dependency_spec.rb
+++ b/spec/models/view_dependency_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Viewy::Models::ViewDependency do
   describe 'columns' do
-    it { is_expected.to have_db_column(:view_name).of_type(:string) }
+    it { is_expected.to have_db_column(:view_name).of_type(:text) }
     it { is_expected.to have_db_column(:materialized_view).of_type(:boolean) }
     it { is_expected.to have_db_column(:view_dependencies) }
   end

--- a/spec/sql_verification_spec.rb
+++ b/spec/sql_verification_spec.rb
@@ -8,7 +8,7 @@ describe 'Viewy sql functions' do
     context 'there are no views in the hierarchy' do
       it 'returns the dependencies for the passed view' do
         result = ActiveRecord::Base.connection.execute <<-SQL
-          SELECT view_dependencies('mat_view_5');
+          SELECT view_dependencies('mat_view_5', 'public');
         SQL
         dependencies = '{public.mat_view_3,public.mat_view_1}'
 
@@ -18,7 +18,7 @@ describe 'Viewy sql functions' do
     context 'there no views in the hierarchy' do
       it 'returns the materialized dependencies for the passed view' do
         result = ActiveRecord::Base.connection.execute <<-SQL
-          SELECT view_dependencies('mat_view_7');
+          SELECT view_dependencies('mat_view_7', 'public');
         SQL
         dependencies_first_tier = %w(public.mat_view_4 public.mat_view_3)
         dependencies_second_tier = %w(public.mat_view_2 public.mat_view_1)
@@ -38,9 +38,10 @@ describe 'Viewy sql functions' do
     context 'there are no views in the hierarchy' do
       it 'returns the dependencies for the passed view' do
         result = ActiveRecord::Base.connection.execute <<-SQL
-          SELECT all_view_dependencies('mat_view_5');
+          SELECT view_dependencies('mat_view_5', 'public');
         SQL
-        dependencies = '{public.mat_view_1,public.mat_view_3}'
+
+        dependencies = '{public.mat_view_3,public.mat_view_1}'
 
         expect(result.values[0][0]).to eql dependencies
       end
@@ -48,7 +49,7 @@ describe 'Viewy sql functions' do
     context 'there are tables in the hierarchy' do
       it 'returns only the vies dependencies for the passed view' do
         result = ActiveRecord::Base.connection.execute <<-SQL
-          SELECT all_view_dependencies('test_view_4');
+          SELECT all_view_dependencies('test_view_4', 'public');
         SQL
         dependencies = '{}'
 
@@ -58,7 +59,7 @@ describe 'Viewy sql functions' do
     context 'there no views in the hierarchy' do
       it 'returns all dependencies for the passed view' do
         result = ActiveRecord::Base.connection.execute <<-SQL
-          SELECT all_view_dependencies('mat_view_7');
+          SELECT all_view_dependencies('mat_view_7', 'public');
         SQL
         dependency_orders = {
           'public.mat_view_3' => %w[public.mat_view_1],
@@ -75,7 +76,7 @@ describe 'Viewy sql functions' do
         # and is not stable from Postgres
         dependency_orders.each do |view, dependencies|
           dependencies.each do |dependency|
-            expect(dependencies_from_server.index(dependency)).to be < dependencies_from_server.index(view)
+            expect(dependencies_from_server.index(dependency)).to be > dependencies_from_server.index(view)
           end
         end
       end

--- a/spec/sql_verification_spec.rb
+++ b/spec/sql_verification_spec.rb
@@ -61,12 +61,10 @@ describe 'Viewy sql functions' do
         result = ActiveRecord::Base.connection.execute <<-SQL
           SELECT all_view_dependencies('mat_view_7', 'public');
         SQL
-        dependency_orders = {
-          'public.mat_view_3' => %w[public.mat_view_1],
-          'public.view_1'     => %w[public.mat_view_2],
-          'public.mat_view_4' => %w[public.view_1],
-          'public.view_3'     => %w[public.mat_view_3]
-        }
+
+        dependencies_first_tier = %w(public.mat_view_4 public.view_3)
+        dependencies_second_tier = %w(public.mat_view_3 public.view_1)
+        dependencies_third_tier = %w(public.mat_view_2 public.mat_view_1)
 
         dependencies_from_server = result.values[0][0]
         dependencies_from_server = dependencies_from_server[1..dependencies_from_server.length - 2].split(',')
@@ -74,11 +72,9 @@ describe 'Viewy sql functions' do
 
         # So long as all dependencies from the server are present in the correct tier ordering does not matter,
         # and is not stable from Postgres
-        dependency_orders.each do |view, dependencies|
-          dependencies.each do |dependency|
-            expect(dependencies_from_server.index(dependency)).to be > dependencies_from_server.index(view)
-          end
-        end
+        expect(dependencies_from_server[0..1]).to match_array dependencies_first_tier
+        expect(dependencies_from_server[2..3]).to match_array dependencies_second_tier
+        expect(dependencies_from_server[4..5]).to match_array dependencies_third_tier
       end
     end
   end

--- a/viewy.gemspec
+++ b/viewy.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'listen'
   s.add_development_dependency 'pg', '< 1.0'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers', '~> 3.0'
 end


### PR DESCRIPTION
Currently getting one failing test that looks quite important, but I'm not sure why my changes would've broken it:

```
  1) Viewy sql functions all_view_dependencies there no views in the hierarchy returns all dependencies for the passed view
     Failure/Error: expect(dependencies_from_server.index(dependency)).to be < dependencies_from_server.index(view)

       expected: < 1
            got:   3
     # ./spec/sql_verification_spec.rb:80:in `block (6 levels) in <top (required)>'
     # ./spec/sql_verification_spec.rb:79:in `each'
     # ./spec/sql_verification_spec.rb:79:in `block (5 levels) in <top (required)>'
     # ./spec/sql_verification_spec.rb:78:in `each'
     # ./spec/sql_verification_spec.rb:78:in `block (4 levels) in <top (required)>'
```